### PR TITLE
feat(purchase_invoice_legacy): restore 12.0 style purchase invoicing

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,11 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.11.1
+_commit: v1.14.1
 _src_path: https://github.com/OCA/oca-addons-repo-template.git
 ci: GitHub
 dependency_installation_mode: PIP
 generate_requirements_txt: true
 github_check_license: true
+github_ci_extra_env: {}
 github_enable_codecov: false
 github_enable_makepot: false
 github_enable_stale_action: false

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
               fi
           done
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     name: ${{ matrix.name }}
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,11 @@ repos:
         entry: found forbidden files; remove them
         language: fail
         files: "\\.rej$"
+      - id: en-po-files
+        name: en.po files cannot exist
+        entry: found a en.po file
+        language: fail
+        files: '[a-zA-Z0-9_]*/i18n/en\.po$'
   - repo: https://github.com/oca/maintainer-tools
     rev: dfba427ba03900b69e0a7f2c65890dc48921d36a
     hooks:
@@ -96,7 +101,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py

--- a/purchase_invoice_legacy/README.rst
+++ b/purchase_invoice_legacy/README.rst
@@ -1,0 +1,7 @@
+=======================
+purchase_invoice_legacy
+=======================
+
+Restores the 12.0 functionality of being allowed to invoice a purchase order,
+effectively at any time, irrespective of the `purchase_method` (control policy).
+

--- a/purchase_invoice_legacy/__init__.py
+++ b/purchase_invoice_legacy/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/purchase_invoice_legacy/__manifest__.py
+++ b/purchase_invoice_legacy/__manifest__.py
@@ -1,0 +1,10 @@
+{
+    "name": "purchase_invoice_legacy",
+    "summary": "Restores 12.0 style invoicing to purchase orders",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/purchase",
+    "category": "Inventory",
+    "version": "15.0.1.0.0",
+    "depends": ["purchase"],
+    "license": "LGPL-3",
+}

--- a/purchase_invoice_legacy/models/__init__.py
+++ b/purchase_invoice_legacy/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase

--- a/purchase_invoice_legacy/models/purchase.py
+++ b/purchase_invoice_legacy/models/purchase.py
@@ -1,0 +1,88 @@
+from odoo import _, models
+from odoo.exceptions import UserError
+from odoo.tools import float_compare
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    def action_create_invoice(self):
+        if self.env.context.get("skip_purchase_invoice_legacy"):
+            return super().action_create_invoice()
+
+        moves = self.env["account.move"]
+        for record in self:
+            moves |= record._action_create_invoice_legacy_mode()
+        return self.action_view_invoice(moves)
+
+    def _action_create_invoice_legacy_mode(self):
+        # 12.0 allowed you to effectively create an invoice at any time
+        # This restores that functionality
+        self.ensure_one()
+
+        if self.state not in ("purchase", "draft"):
+            raise UserError(_("Purchase order must be in 'purchase' or 'draft' state!"))
+
+        self.env["decimal.precision"].precision_get("Product Unit of Measure")
+
+        sequence = 10
+        order = self.with_company(self.company_id)
+        pending_section = None
+
+        # Invoice values.
+        invoice_vals = order._prepare_invoice()
+
+        for line in order.order_line:
+            if line.display_type == "line_section":
+                pending_section = line
+                continue
+
+            if pending_section:
+                line_vals = pending_section._prepare_account_move_line_legacy_mode()
+                line_vals.update({"sequence": sequence})
+                invoice_vals["invoice_line_ids"].append((0, 0, line_vals))
+                sequence += 1
+                pending_section = None
+
+            line_vals = line._prepare_account_move_line_legacy_mode()
+            line_vals.update({"sequence": sequence})
+            invoice_vals["invoice_line_ids"].append((0, 0, line_vals))
+            sequence += 1
+
+        if not invoice_vals:
+            raise UserError(
+                _(
+                    "There is no invoiceable line. If a product has a control"
+                    " policy based on received quantity, please make sure that"
+                    " a quantity has been received."
+                )
+            )
+
+        return (
+            self.env["account.move"]
+            .with_context(default_move_type="in_invoice")
+            .create(invoice_vals)
+        )
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    def _prepare_account_move_line_legacy_mode(self, move=False):
+        res = self._prepare_account_move_line(move)
+
+        if not self.display_type and self.product_id and self.product_uom:
+            # use 12.0 logic to determine the actual quantity
+            if self.product_id.purchase_method == "purchase":
+                qty = self.product_qty - self.qty_invoiced
+            else:
+                qty = self.qty_received - self.qty_invoiced
+            if (
+                float_compare(qty, 0.0, precision_rounding=self.product_uom.rounding)
+                <= 0
+            ):
+                qty = 0.0
+
+            res.update({"quantity": qty})
+
+        return res

--- a/purchase_invoice_legacy/tests/__init__.py
+++ b/purchase_invoice_legacy/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_purchase

--- a/purchase_invoice_legacy/tests/test_purchase.py
+++ b/purchase_invoice_legacy/tests/test_purchase.py
@@ -1,0 +1,79 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPurchase(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestPurchase, cls).setUpClass()
+        cls.partner_a = cls.env["res.partner"].create({"name": "Supplier Partner A"})
+        cls.product_a = cls.env["product.product"].create(
+            {
+                "name": "Test Receiving Product A",
+                "purchase_method": "receive",
+                "type": "consu",
+            }
+        )
+
+    def test_received_prepare_account_move_line_legacy_mode(self):
+        purchase_id = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_a.id,
+                            "product_qty": 10,
+                        },
+                    )
+                ],
+            }
+        )
+
+        purchase_id.button_confirm()
+
+        vals = purchase_id.order_line._prepare_account_move_line_legacy_mode()
+        self.assertEqual(vals.get("quantity", 0.0), 0.0)
+
+        purchase_id.order_line.qty_received_method = "manual"
+        purchase_id.order_line.qty_received_manual = 5
+
+        vals = purchase_id.order_line._prepare_account_move_line_legacy_mode()
+        self.assertEqual(vals.get("quantity", 0.0), 5.0)
+
+        purchase_id.order_line.qty_received_method = "manual"
+        purchase_id.order_line.qty_received_manual = 10
+
+        vals = purchase_id.order_line._prepare_account_move_line_legacy_mode()
+        self.assertEqual(vals.get("quantity", 0.0), 10.0)
+
+    def test_received_real_invoice(self):
+        purchase_id = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_a.id,
+                            "product_qty": 10,
+                        },
+                    )
+                ],
+            }
+        )
+
+        purchase_id.button_confirm()
+        move = purchase_id._action_create_invoice_legacy_mode()
+        move.invoice_line_ids.quantity = 5
+
+        vals = purchase_id.order_line._prepare_account_move_line_legacy_mode()
+        self.assertEqual(vals.get("quantity", 0.0), 0.0)
+
+        purchase_id.order_line.qty_received_method = "manual"
+        purchase_id.order_line.qty_received_manual = 10
+        vals = purchase_id.order_line._prepare_account_move_line_legacy_mode()
+        self.assertEqual(vals.get("quantity", 0.0), 5.0)

--- a/setup/purchase_invoice_legacy/odoo/addons/purchase_invoice_legacy
+++ b/setup/purchase_invoice_legacy/odoo/addons/purchase_invoice_legacy
@@ -1,0 +1,1 @@
+../../../../purchase_invoice_legacy

--- a/setup/purchase_invoice_legacy/setup.py
+++ b/setup/purchase_invoice_legacy/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
## Description

New module that restore 12.0-style "lax" invoicing to purchase orders.

Fixes T5568

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

