### PR TITLE
feat(product_supplier_info_apply_on_variants): initial commit

### DIFF
--- a/product_supplier_info_apply_on_variants/README.rst
+++ b/product_supplier_info_apply_on_variants/README.rst
@@ -1,0 +1,6 @@
+=======================================
+product_supplier_info_apply_on_variants
+=======================================
+
+Apply on variants functionality for product.supplierinfo records.
+

--- a/product_supplier_info_apply_on_variants/__init__.py
+++ b/product_supplier_info_apply_on_variants/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_supplier_info_apply_on_variants/__manifest__.py
+++ b/product_supplier_info_apply_on_variants/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "product_supplier_info_apply_on_variants",
+    "summary": "Apply on Variants for product.supplierinfo records",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/purchase",
+    "category": "Uncategorized",
+    "version": "15.0.1.0.0",
+    "depends": ["product"],
+    "data": [
+        "views/product_supplierinfo.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/product_supplier_info_apply_on_variants/models/__init__.py
+++ b/product_supplier_info_apply_on_variants/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_supplierinfo

--- a/product_supplier_info_apply_on_variants/models/product_supplierinfo.py
+++ b/product_supplier_info_apply_on_variants/models/product_supplierinfo.py
@@ -4,15 +4,6 @@ from odoo import api, fields, models
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
-    def _match_all_variant_values(self, product_template_attribute_value_ids):
-        """It currently checks that all variant values (`product_template_attribute_value_ids`)
-        are in the product (`self`).
-
-        If multiple values are encoded for the same attribute line, only one of
-        them has to be found on the variant.
-        """
-        self.ensure_one()
-
     def _prepare_sellers(self, params=False):
         self.ensure_one()
         res = super()._prepare_sellers(params)

--- a/product_supplier_info_apply_on_variants/models/product_supplierinfo.py
+++ b/product_supplier_info_apply_on_variants/models/product_supplierinfo.py
@@ -5,7 +5,7 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     def _match_all_variant_values(self, product_template_attribute_value_ids):
-        """ It currently checks that all variant values (`product_template_attribute_value_ids`)
+        """It currently checks that all variant values (`product_template_attribute_value_ids`)
         are in the product (`self`).
 
         If multiple values are encoded for the same attribute line, only one of
@@ -13,14 +13,14 @@ class ProductProduct(models.Model):
         """
         self.ensure_one()
 
-
     def _prepare_sellers(self, params=False):
         self.ensure_one()
         res = super()._prepare_sellers(params)
         to_remove = self.env["product.supplierinfo"]
 
         for record in res.filtered(lambda p: p.apply_on_ptav_ids and not p.product_id):
-            # This is basically a straight clone from mrp, product.template _match_all_variant_values method
+            # This is basically a straight clone from mrp, product.template
+            # _match_all_variant_values method
             # https://github.com/odoo/odoo/blob/15.0/addons/mrp/models/product.py#L304
             # Copied so that we do not need to depend on `mrp`.
             #
@@ -28,7 +28,9 @@ class ProductProduct(models.Model):
             # * the number of items equals the number of attributes (since a product cannot
             #   have multiple values for the same attribute),
             # * the attributes are a subset of the attributes of the line.
-            matches_all = len(self.product_template_attribute_value_ids & record.apply_on_ptav_ids) == len(record.apply_on_ptav_ids.attribute_id)
+            matches_all = len(
+                self.product_template_attribute_value_ids & record.apply_on_ptav_ids
+            ) == len(record.apply_on_ptav_ids.attribute_id)
             if not matches_all:
                 to_remove |= record
 

--- a/product_supplier_info_apply_on_variants/models/product_supplierinfo.py
+++ b/product_supplier_info_apply_on_variants/models/product_supplierinfo.py
@@ -4,13 +4,32 @@ from odoo import api, fields, models
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
+    def _match_all_variant_values(self, product_template_attribute_value_ids):
+        """ It currently checks that all variant values (`product_template_attribute_value_ids`)
+        are in the product (`self`).
+
+        If multiple values are encoded for the same attribute line, only one of
+        them has to be found on the variant.
+        """
+        self.ensure_one()
+
+
     def _prepare_sellers(self, params=False):
         self.ensure_one()
         res = super()._prepare_sellers(params)
         to_remove = self.env["product.supplierinfo"]
 
         for record in res.filtered(lambda p: p.apply_on_ptav_ids and not p.product_id):
-            if not self._match_all_variant_values(record.apply_on_ptav_ids):
+            # This is basically a straight clone from mrp, product.template _match_all_variant_values method
+            # https://github.com/odoo/odoo/blob/15.0/addons/mrp/models/product.py#L304
+            # Copied so that we do not need to depend on `mrp`.
+            #
+            # The intersection of the values of the product and those of the line satisfy:
+            # * the number of items equals the number of attributes (since a product cannot
+            #   have multiple values for the same attribute),
+            # * the attributes are a subset of the attributes of the line.
+            matches_all = len(self.product_template_attribute_value_ids & record.apply_on_ptav_ids) == len(record.apply_on_ptav_ids.attribute_id)
+            if not matches_all:
                 to_remove |= record
 
         return res - to_remove

--- a/product_supplier_info_apply_on_variants/models/product_supplierinfo.py
+++ b/product_supplier_info_apply_on_variants/models/product_supplierinfo.py
@@ -1,0 +1,50 @@
+from odoo import api, fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _prepare_sellers(self, params=False):
+        self.ensure_one()
+        res = super()._prepare_sellers(params)
+        to_remove = self.env["product.supplierinfo"]
+
+        for record in res.filtered(lambda p: p.apply_on_ptav_ids and not p.product_id):
+            if not self._match_all_variant_values(record.apply_on_ptav_ids):
+                to_remove |= record
+
+        return res - to_remove
+
+
+class ProductSupplierInfo(models.Model):
+    _inherit = "product.supplierinfo"
+
+    possible_ptav_ids = fields.Many2many(
+        "product.template.attribute.value", compute="_compute_possible_ptav_ids"
+    )
+    apply_on_ptav_ids = fields.Many2many(
+        "product.template.attribute.value",
+        string="Apply on Variants",
+        ondelete="restrict",
+        domain="[('id', 'in', possible_ptav_ids)]",
+    )
+
+    @api.depends(
+        "product_tmpl_id.attribute_line_ids.value_ids",
+        "product_tmpl_id.attribute_line_ids.attribute_id.create_variant",
+        "product_tmpl_id.attribute_line_ids.product_template_value_ids.ptav_active",
+    )
+    def _compute_possible_ptav_ids(self):
+        for record in self:
+            # Disable formatting as black attempts to make this 1 very very
+            # large line
+            # fmt: off
+            record.possible_ptav_ids = (
+                record
+                .product_tmpl_id
+                .valid_product_template_attribute_line_ids
+                ._without_no_variant_attributes()
+                .product_template_value_ids
+                ._only_active()
+            )
+            # fmt: on

--- a/product_supplier_info_apply_on_variants/tests/__init__.py
+++ b/product_supplier_info_apply_on_variants/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_supplier_info

--- a/product_supplier_info_apply_on_variants/tests/test_supplier_info.py
+++ b/product_supplier_info_apply_on_variants/tests/test_supplier_info.py
@@ -1,0 +1,176 @@
+from odoo.fields import Command
+from odoo.tests import TransactionCase, tagged
+from odoo.tools import float_compare
+
+
+@tagged("post_install", "-at_install")
+class TestSupplierInfo(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.wood_corner = cls.env["res.partner"].create({"name": "Wood Corner"})
+        cls.azure_int = cls.env["res.partner"].create({"name": "Azure Interior"})
+
+    def test_default_select_seller(self):
+        self.ipad_mini, self.monitor = self.env["product.product"].create(
+            [
+                {
+                    "name": "Large Cabinet",
+                    "standard_price": 800.0,
+                },
+                {
+                    "name": "Super nice monitor",
+                    "list_price": 1000.0,
+                },
+            ]
+        )
+
+        self.env["product.supplierinfo"].create(
+            [
+                {
+                    "name": self.wood_corner.id,
+                    "product_tmpl_id": self.ipad_mini.product_tmpl_id.id,
+                    "delay": 3,
+                    "min_qty": 1,
+                    "price": 750,
+                },
+                {
+                    "name": self.azure_int.id,
+                    "product_tmpl_id": self.ipad_mini.product_tmpl_id.id,
+                    "delay": 3,
+                    "min_qty": 1,
+                    "price": 790,
+                },
+                {
+                    "name": self.azure_int.id,
+                    "product_tmpl_id": self.ipad_mini.product_tmpl_id.id,
+                    "delay": 3,
+                    "min_qty": 3,
+                    "price": 785,
+                },
+                {
+                    "name": self.azure_int.id,
+                    "product_tmpl_id": self.monitor.product_tmpl_id.id,
+                    "delay": 3,
+                    "min_qty": 3,
+                    "price": 100,
+                },
+            ]
+        )
+
+        product = self.ipad_mini
+
+        # Supplierinfo pricing
+
+        # Check cost price of ipad mini
+        price = product._select_seller(partner_id=self.azure_int, quantity=1.0).price
+        self.assertEqual(float_compare(price, 790, precision_digits=2), 0)
+
+        # Check cost price of ipad mini if more than 3 Unit
+        price = product._select_seller(partner_id=self.azure_int, quantity=3.0).price
+        self.assertEqual(float_compare(price, 785, precision_digits=2), 0)
+
+    def test_apply_on_variants(self):
+        attrib_memory = self.env["product.attribute"].create(
+            {
+                "name": "Storage",
+                "sequence": 1,
+                "value_ids": [
+                    Command.create(
+                        {
+                            "name": "256 GB",
+                            "sequence": 1,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "name": "512 GB",
+                            "sequence": 2,
+                        }
+                    ),
+                ],
+            }
+        )
+
+        attrib_value_256, attrib_value_512 = attrib_memory.value_ids
+
+        thingy = self.env["product.template"].create(
+            {
+                "name": "Thingy with memory",
+                "attribute_line_ids": [
+                    Command.create(
+                        {
+                            "attribute_id": attrib_memory.id,
+                            "value_ids": [
+                                Command.set([attrib_value_256.id, attrib_value_512.id])
+                            ],
+                        }
+                    )
+                ],
+            }
+        )
+
+        thingy_256, thingy_512 = thingy.product_variant_ids
+
+        self.env["product.supplierinfo"].create(
+            [
+                {
+                    "sequence": 1,
+                    "name": self.azure_int.id,
+                    "product_tmpl_id": thingy.id,
+                    "delay": 3,
+                    "min_qty": 99,
+                    "price": 1,
+                },
+                {
+                    "sequence": 2,
+                    "name": self.azure_int.id,
+                    "product_tmpl_id": thingy.id,
+                    "delay": 3,
+                    "min_qty": 1,
+                    "price": 2,
+                    "apply_on_ptav_ids": [
+                        Command.set(thingy_512.product_template_attribute_value_ids.ids)
+                    ],
+                },
+                {
+                    "sequence": 3,
+                    "name": self.azure_int.id,
+                    "product_tmpl_id": thingy.id,
+                    "delay": 3,
+                    "min_qty": 1,
+                    "price": 3,
+                    "apply_on_ptav_ids": [
+                        Command.set(thingy_256.product_template_attribute_value_ids.ids)
+                    ],
+                },
+            ]
+        )
+
+        # price for 99+ is always 790
+
+        price = thingy_256._select_seller(
+            partner_id=self.azure_int, quantity=99.0
+        ).price
+        self.assertEqual(
+            float_compare(price, 1, precision_digits=2), 0, f"{price} != 1"
+        )
+
+        price = thingy_512._select_seller(
+            partner_id=self.azure_int, quantity=99.0
+        ).price
+        self.assertEqual(
+            float_compare(price, 1, precision_digits=2), 0, f"{price} != 1"
+        )
+
+        # now test apply on variants
+
+        price = thingy_256._select_seller(partner_id=self.azure_int, quantity=1.0).price
+        self.assertEqual(
+            float_compare(price, 3, precision_digits=2), 0, f"{price} != 3"
+        )
+
+        price = thingy_512._select_seller(partner_id=self.azure_int, quantity=1.0).price
+        self.assertEqual(
+            float_compare(price, 2, precision_digits=2), 0, f"{price} != 2"
+        )

--- a/product_supplier_info_apply_on_variants/views/product_supplierinfo.xml
+++ b/product_supplier_info_apply_on_variants/views/product_supplierinfo.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <record id="product_supplierinfo_tree_view" model="ir.ui.view">
+        <field name="name">product_supplierinfo_tree_view</field>
+        <field name="model">product.supplierinfo</field>
+        <field name="inherit_id" ref="product.product_supplierinfo_tree_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree/field[@name='product_tmpl_id']" position="after">
+                <field name="possible_ptav_ids" widget="many2many_tags" invisible="1" />
+                <field
+                    name="apply_on_ptav_ids"
+                    widget="many2many_tags"
+                    attrs="{'invisible': [('product_id', '!=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/product_supplier_info_apply_on_variants/odoo/addons/product_supplier_info_apply_on_variants
+++ b/setup/product_supplier_info_apply_on_variants/odoo/addons/product_supplier_info_apply_on_variants
@@ -1,0 +1,1 @@
+../../../../product_supplier_info_apply_on_variants

--- a/setup/product_supplier_info_apply_on_variants/setup.py
+++ b/setup/product_supplier_info_apply_on_variants/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
## Description

Adds an "apply on variants" functionality.

This is to be used in conjunction with GlodoUK/CPQ modules, or any other scenario where variants that do not exist yet require pricing on product.supplierinfo.

![image](https://github.com/GlodoUK/purchase/assets/309967/7f19a6b0-048c-4357-9197-3b8b3aa36fd3)

Fixes T9452

Associated risk level low

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

